### PR TITLE
Refactor: k-openssl

### DIFF
--- a/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/Password.kt
+++ b/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/Password.kt
@@ -17,12 +17,13 @@ package io.matthewnelson.k_openssl_common.clazzes
 
 import io.matthewnelson.k_openssl_common.annotations.RawPasswordAccess
 
-inline class Password(@property: RawPasswordAccess val value: CharArray) {
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(RawPasswordAccess::class)
+inline fun Password.clear(char: Char = '0') {
+    value.fill(char)
+}
 
-    @OptIn(RawPasswordAccess::class)
-    fun clear() {
-        value.fill('*')
-    }
+inline class Password(@property: RawPasswordAccess val value: CharArray) {
 
     @Throws(IllegalAccessException::class)
     override fun toString(): String {

--- a/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/Sha256Hash.kt
+++ b/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/Sha256Hash.kt
@@ -23,19 +23,17 @@ import java.security.MessageDigest
 inline fun ByteArray.toSha256Hash(): Sha256Hash {
     MessageDigest.getInstance("SHA-256").let { digest ->
         digest.reset()
-        digest.update(this, 0, this.size)
+        digest.update(this, 0, size)
         return Sha256Hash(digest.digest().toHex())
     }
 }
 
 @Suppress("NOTHING_TO_INLINE")
 inline fun String.toSha256Hash(): Sha256Hash =
-    this.encodeToByteArray().toSha256Hash()
+    encodeToByteArray().toSha256Hash()
 
-class Sha256Hash(val value: String) {
+inline class Sha256Hash(val value: String) {
 
-    // TODO: Kotlin 1.4.30 update will allow inline classes to
-    //  have init blocks
     init {
         require(isValid(value)) {
             "$value is not a valid Sha256 hash"
@@ -48,9 +46,5 @@ class Sha256Hash(val value: String) {
 
         fun isValid(sha256Hash: ByteArray): Boolean =
             isValid(sha256Hash.toHex())
-    }
-
-    override fun toString(): String {
-        return "Sha256Hash(value=$value)"
     }
 }

--- a/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/UnencryptedByteArray.kt
+++ b/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/UnencryptedByteArray.kt
@@ -21,18 +21,18 @@ import io.matthewnelson.k_openssl_common.extensions.toCharArray
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(UnencryptedDataAccess::class)
 inline fun UnencryptedByteArray.clear(char: Char = '0') {
-    this.value.fill(char.toByte())
+    value.fill(char.toByte())
 }
 
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(UnencryptedDataAccess::class)
 inline fun UnencryptedByteArray.toUnencryptedCharArray(): UnencryptedCharArray =
-    UnencryptedCharArray(this.value.toCharArray())
+    UnencryptedCharArray(value.toCharArray())
 
 @Suppress("NOTHING_TO_INLINE")
 @OptIn(UnencryptedDataAccess::class)
 inline fun UnencryptedByteArray.toUnencryptedString(): UnencryptedString =
-    UnencryptedString(this.value.toString(charset("UTF-8")).trim())
+    UnencryptedString(value.toString(charset("UTF-8")).trim())
 
 inline class UnencryptedByteArray(@property: UnencryptedDataAccess val value: ByteArray) {
 

--- a/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/UnencryptedByteArray.kt
+++ b/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/UnencryptedByteArray.kt
@@ -18,23 +18,26 @@ package io.matthewnelson.k_openssl_common.clazzes
 import io.matthewnelson.k_openssl_common.annotations.UnencryptedDataAccess
 import io.matthewnelson.k_openssl_common.extensions.toCharArray
 
-inline class UnencryptedByteArray(@property: UnencryptedDataAccess val value: ByteArray) {
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(UnencryptedDataAccess::class)
+inline fun UnencryptedByteArray.clear(char: Char = '0') {
+    this.value.fill(char.toByte())
+}
 
-    @OptIn(UnencryptedDataAccess::class)
-    fun clear() {
-        value.fill('*'.toByte())
-    }
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(UnencryptedDataAccess::class)
+inline fun UnencryptedByteArray.toUnencryptedCharArray(): UnencryptedCharArray =
+    UnencryptedCharArray(this.value.toCharArray())
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(UnencryptedDataAccess::class)
+inline fun UnencryptedByteArray.toUnencryptedString(): UnencryptedString =
+    UnencryptedString(this.value.toString(charset("UTF-8")).trim())
+
+inline class UnencryptedByteArray(@property: UnencryptedDataAccess val value: ByteArray) {
 
     @Throws(IllegalAccessException::class)
     override fun toString(): String {
         throw IllegalAccessException("toUnencryptedString must be used.")
     }
-
-    @OptIn(UnencryptedDataAccess::class)
-    fun toUnencryptedCharArray(): UnencryptedCharArray =
-        UnencryptedCharArray(value.toCharArray())
-
-    @OptIn(UnencryptedDataAccess::class)
-    fun toUnencryptedString(): UnencryptedString =
-        UnencryptedString(value.toString(Charsets.UTF_8).trim())
 }

--- a/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/UnencryptedCharArray.kt
+++ b/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/UnencryptedCharArray.kt
@@ -18,23 +18,26 @@ package io.matthewnelson.k_openssl_common.clazzes
 import io.matthewnelson.k_openssl_common.annotations.UnencryptedDataAccess
 import io.matthewnelson.k_openssl_common.extensions.toByteArray
 
-inline class UnencryptedCharArray(@property: UnencryptedDataAccess val value: CharArray) {
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(UnencryptedDataAccess::class)
+inline fun UnencryptedCharArray.clear(char: Char = '0') {
+    value.fill(char)
+}
 
-    @OptIn(UnencryptedDataAccess::class)
-    fun clear() {
-        value.fill('*')
-    }
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(UnencryptedDataAccess::class)
+inline fun UnencryptedCharArray.toUnencryptedByteArray(): UnencryptedByteArray =
+    UnencryptedByteArray(value.toByteArray())
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(UnencryptedDataAccess::class)
+inline fun UnencryptedCharArray.toUnencryptedString(): UnencryptedString =
+    UnencryptedString(value.joinToString(""))
+
+inline class UnencryptedCharArray(@property: UnencryptedDataAccess val value: CharArray) {
 
     @Throws(IllegalAccessException::class)
     override fun toString(): String {
         throw IllegalAccessException("toUnencryptedString must be used.")
     }
-
-    @OptIn(UnencryptedDataAccess::class)
-    fun toUnencryptedString(): UnencryptedString =
-        UnencryptedString(value.joinToString(""))
-
-    @OptIn(UnencryptedDataAccess::class)
-    fun toUnencryptedByteArray(): UnencryptedByteArray =
-        UnencryptedByteArray(value.toByteArray())
 }

--- a/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/UnencryptedString.kt
+++ b/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/clazzes/UnencryptedString.kt
@@ -16,5 +16,16 @@
 package io.matthewnelson.k_openssl_common.clazzes
 
 import io.matthewnelson.k_openssl_common.annotations.UnencryptedDataAccess
+import io.matthewnelson.k_openssl_common.extensions.encodeToByteArray
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(UnencryptedDataAccess::class)
+inline fun UnencryptedString.toUnencryptedByteArray(): UnencryptedByteArray =
+    UnencryptedByteArray(value.encodeToByteArray())
+
+@Suppress("NOTHING_TO_INLINE")
+@OptIn(UnencryptedDataAccess::class)
+inline fun UnencryptedString.toUnencryptedCharArray(): UnencryptedCharArray =
+    UnencryptedCharArray(value.toCharArray())
 
 inline class UnencryptedString(@property: UnencryptedDataAccess val value: String)

--- a/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/extensions/Extensions.kt
+++ b/kotlin/crypto/k-openssl-common/src/main/java/io/matthewnelson/k_openssl_common/extensions/Extensions.kt
@@ -20,13 +20,13 @@ import java.nio.CharBuffer
 
 /** securely converts a ByteArray to a CharArray */
 @Suppress("NOTHING_TO_INLINE")
-inline fun ByteArray.toCharArray(): CharArray =
+inline fun ByteArray.toCharArray(fill: Char = '0'): CharArray =
     this.copyOf().let { copyByteArray ->
         ByteBuffer.wrap(copyByteArray).let { byteBuffer ->
             charset("UTF-8").newDecoder().decode(byteBuffer).let { charBuffer ->
                 charBuffer.array().copyOf(charBuffer.limit()).let { charArray ->
-                    byteBuffer.array().fill('*'.toByte())
-                    charBuffer.array().fill('*')
+                    byteBuffer.array().fill(fill.toByte())
+                    charBuffer.array().fill(fill)
                     charArray
                 }
             }
@@ -35,13 +35,13 @@ inline fun ByteArray.toCharArray(): CharArray =
 
 /** securely converts a CharArray to a ByteArray */
 @Suppress("NOTHING_TO_INLINE")
-inline fun CharArray.toByteArray(): ByteArray =
+inline fun CharArray.toByteArray(fill: Char = '0'): ByteArray =
     this.copyOf().let { copyCharArray ->
         CharBuffer.wrap(copyCharArray).let { charBuffer ->
             charset("UTF-8").newEncoder().encode(charBuffer).let { byteBuffer ->
                 byteBuffer.array().copyOf(byteBuffer.limit()).let { byteArray ->
-                    charBuffer.array().fill('*')
-                    byteBuffer.array().fill('*'.toByte())
+                    charBuffer.array().fill(fill)
+                    byteBuffer.array().fill(fill.toByte())
                     byteArray
                 }
             }

--- a/kotlin/crypto/k-openssl/src/main/java/io/matthewnelson/k_openssl/KOpenSSL.kt
+++ b/kotlin/crypto/k-openssl/src/main/java/io/matthewnelson/k_openssl/KOpenSSL.kt
@@ -17,6 +17,7 @@ package io.matthewnelson.k_openssl
 
 import io.matthewnelson.k_openssl_common.annotations.RawPasswordAccess
 import io.matthewnelson.k_openssl_common.clazzes.*
+import io.matthewnelson.k_openssl_common.extensions.encodeToByteArray
 import io.matthewnelson.k_openssl_common.extensions.toByteArray
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
@@ -46,7 +47,7 @@ abstract class KOpenSSL {
                 chars.lines().joinToString("")
                     .decodeBase64ToArray()
                     ?.copyOfRange(0, 8)
-                    ?.contentEquals(SALTED.toByteArray())
+                    ?.contentEquals(SALTED.encodeToByteArray())
                     ?: false
             } catch (e: Exception) {
                 false
@@ -178,7 +179,7 @@ abstract class KOpenSSL {
 
     @Throws(IllegalStateException::class)
     protected open fun encodeCipherText(salt: ByteArray, cipherText: ByteArray): String =
-        (SALTED.toByteArray() + salt + cipherText)
+        (SALTED.encodeToByteArray() + salt + cipherText)
             .encodeBase64()
             .replace("(.{64})".toRegex(), "$1\n")
 

--- a/kotlin/crypto/k-openssl/src/main/java/io/matthewnelson/k_openssl/algos/AES256CBC_PBKDF2_HMAC_SHA256.kt
+++ b/kotlin/crypto/k-openssl/src/main/java/io/matthewnelson/k_openssl/algos/AES256CBC_PBKDF2_HMAC_SHA256.kt
@@ -18,6 +18,7 @@ package io.matthewnelson.k_openssl.algos
 import io.matthewnelson.k_openssl_common.annotations.UnencryptedDataAccess
 import io.matthewnelson.k_openssl.KOpenSSL
 import io.matthewnelson.k_openssl_common.clazzes.*
+import io.matthewnelson.k_openssl_common.extensions.encodeToByteArray
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.withContext
@@ -179,7 +180,7 @@ class AES256CBC_PBKDF2_HMAC_SHA256: KOpenSSL() {
         unencryptedString: UnencryptedString,
         dispatcher: CoroutineDispatcher
     ): EncryptedString =
-        UnencryptedByteArray(unencryptedString.value.toByteArray()).let { unencryptedByteArray ->
+        UnencryptedByteArray(unencryptedString.value.encodeToByteArray()).let { unencryptedByteArray ->
             encrypt(
                 password,
                 hashIterations,

--- a/kotlin/crypto/k-openssl/src/main/java/io/matthewnelson/k_openssl/algos/AES256CBC_PBKDF2_HMAC_SHA256.kt
+++ b/kotlin/crypto/k-openssl/src/main/java/io/matthewnelson/k_openssl/algos/AES256CBC_PBKDF2_HMAC_SHA256.kt
@@ -180,7 +180,7 @@ class AES256CBC_PBKDF2_HMAC_SHA256: KOpenSSL() {
         unencryptedString: UnencryptedString,
         dispatcher: CoroutineDispatcher
     ): EncryptedString =
-        UnencryptedByteArray(unencryptedString.value.encodeToByteArray()).let { unencryptedByteArray ->
+        unencryptedString.toUnencryptedByteArray().let { unencryptedByteArray ->
             encrypt(
                 password,
                 hashIterations,

--- a/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/components/AuthenticationManagerImpl.kt
+++ b/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/components/AuthenticationManagerImpl.kt
@@ -27,6 +27,7 @@ import io.matthewnelson.concept_encryption_key.EncryptionKeyException
 import io.matthewnelson.concept_encryption_key.EncryptionKeyHandler
 import io.matthewnelson.k_openssl_common.annotations.RawPasswordAccess
 import io.matthewnelson.k_openssl_common.clazzes.HashIterations
+import io.matthewnelson.k_openssl_common.clazzes.clear
 import kotlinx.coroutines.flow.*
 
 /**

--- a/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/model/Credentials.kt
+++ b/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/model/Credentials.kt
@@ -21,9 +21,7 @@ import io.matthewnelson.concept_encryption_key.EncryptionKeyHandler
 import io.matthewnelson.feature_authentication_core.components.AuthenticationProcessor
 import io.matthewnelson.k_openssl.KOpenSSL
 import io.matthewnelson.k_openssl_common.annotations.UnencryptedDataAccess
-import io.matthewnelson.k_openssl_common.clazzes.EncryptedString
-import io.matthewnelson.k_openssl_common.clazzes.HashIterations
-import io.matthewnelson.k_openssl_common.clazzes.Password
+import io.matthewnelson.k_openssl_common.clazzes.*
 
 internal class Credentials private constructor(
     private val encryptedEncryptionKey: EncryptedString,

--- a/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/model/PinWriter.kt
+++ b/kotlin/features/authentication/feature-authentication-core/src/main/java/io/matthewnelson/feature_authentication_core/model/PinWriter.kt
@@ -17,6 +17,7 @@ package io.matthewnelson.feature_authentication_core.model
 
 import io.matthewnelson.k_openssl_common.annotations.RawPasswordAccess
 import io.matthewnelson.k_openssl_common.clazzes.Password
+import io.matthewnelson.k_openssl_common.clazzes.clear
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -60,14 +60,16 @@ android {
 
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
-    implementation project(path: ':android:features:android-feature-views')
+    implementation project(path: ':android:features:android-feature-activity')
+    implementation project(path: ':android:features:android-feature-screens')
     implementation project(path: ':android:features:authentication:android-feature-authentication-core')
     implementation project(path: ':kotlin:common:build-config')
-    implementation project(path: ':kotlin:concepts:navigation:concept-navigation-driver')
+    implementation project(path: ':kotlin:features:feature-navigation')
 
+    implementation deps.androidx.lifecycle.hilt
+    kapt kaptDeps.androidx.lifecycle.hilt
     implementation deps.google.hilt
     kapt kaptDeps.google.hilt
-    kapt kaptDeps.androidx.lifecycle.hilt
 
 //    debugImplementation debugDeps.square.leakCanary
 


### PR DESCRIPTION
This PR refactors the `k-openssl` & `k-openssl-common` modules.
 - Removes usage of `Charsets` to allow for usage with Android API less than 19
 - Cleans up common classes by inlining methods