### PR TITLE
aundroid-feature-authentication-core fixup

### DIFF
--- a/android/features/authentication/android-feature-authentication-core/src/main/java/io/matthewnelson/android_feature_authentication_core/data/AuthenticationSharedPrefsName.kt
+++ b/android/features/authentication/android-feature-authentication-core/src/main/java/io/matthewnelson/android_feature_authentication_core/data/AuthenticationSharedPrefsName.kt
@@ -15,4 +15,10 @@
 * */
 package io.matthewnelson.android_feature_authentication_core.data
 
-inline class AuthenticationSharedPrefsName(val value: String)
+inline class AuthenticationSharedPrefsName(val value: String) {
+    init {
+        require(value.isNotEmpty()) {
+            "AuthenticationSharedPrefsName must not be empty."
+        }
+    }
+}

--- a/android/features/authentication/android-feature-authentication-core/src/main/java/io/matthewnelson/android_feature_authentication_core/data/MasterKeyAlias.kt
+++ b/android/features/authentication/android-feature-authentication-core/src/main/java/io/matthewnelson/android_feature_authentication_core/data/MasterKeyAlias.kt
@@ -15,4 +15,10 @@
 * */
 package io.matthewnelson.android_feature_authentication_core.data
 
-inline class MasterKeyAlias(val value: String)
+inline class MasterKeyAlias(val value: String) {
+    init {
+        require(value.isNotEmpty()) {
+            "MasterKeyAlias must not be empty."
+        }
+    }
+}

--- a/android/features/authentication/android-feature-authentication-core/src/main/java/io/matthewnelson/android_feature_authentication_core/data/PersistentStorageAndroid.kt
+++ b/android/features/authentication/android-feature-authentication-core/src/main/java/io/matthewnelson/android_feature_authentication_core/data/PersistentStorageAndroid.kt
@@ -24,18 +24,18 @@ import io.matthewnelson.concept_coroutines.CoroutineDispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withContext
 
-class PersistentStorageAndroid(
+open class PersistentStorageAndroid(
     context: Context,
     masterKeyAlias: MasterKeyAlias,
     authenticationSharedPrefsName: AuthenticationSharedPrefsName,
-    private val dispatchers: CoroutineDispatchers
+    protected val dispatchers: CoroutineDispatchers
 ): PersistentStorage() {
 
-    private companion object {
-        private const val CREDENTIALS = "CREDENTIALS"
+    companion object {
+        protected const val CREDENTIALS = "CREDENTIALS"
     }
 
-    private val authenticationPrefs: SharedPreferences by lazy {
+    protected val authenticationPrefs: SharedPreferences by lazy {
         EncryptedSharedPreferences.create(
             context.applicationContext,
             authenticationSharedPrefsName.value,


### PR DESCRIPTION
This PR opens up the `PersistentStorageAndroid` class to allow implementors the ability to override some of the settings, if desired.

It also adds some requirements to the inline classes used to initialize EncryptedSharedPreferences such that they cannot be empty string values.