### PR TITLE
modify the 'VERSION_NAME' and 'VERSION_CODE'

### DIFF
--- a/android/concepts/android-concept-views/build.gradle
+++ b/android/concepts/android-concept-views/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion KAversions.minSdk
         targetSdkVersion KAversions.compileSdk
-        versionCode VERSION_CODE.toInteger()
-        versionName VERSION_NAME
+        versionCode KA_VERSION_CODE.toInteger()
+        versionName KA_VERSION_NAME
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments disableAnalytics: 'true'

--- a/android/features/android-feature-activity/build.gradle
+++ b/android/features/android-feature-activity/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion KAversions.minSdk
         targetSdkVersion KAversions.compileSdk
-        versionCode VERSION_CODE.toInteger()
-        versionName VERSION_NAME
+        versionCode KA_VERSION_CODE.toInteger()
+        versionName KA_VERSION_NAME
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments disableAnalytics: 'true'

--- a/android/features/android-feature-navigation/build.gradle
+++ b/android/features/android-feature-navigation/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion KAversions.minSdk
         targetSdkVersion KAversions.compileSdk
-        versionCode VERSION_CODE.toInteger()
-        versionName VERSION_NAME
+        versionCode KA_VERSION_CODE.toInteger()
+        versionName KA_VERSION_NAME
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments disableAnalytics: 'true'

--- a/android/features/android-feature-screens/build.gradle
+++ b/android/features/android-feature-screens/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion KAversions.minSdk
         targetSdkVersion KAversions.compileSdk
-        versionCode VERSION_CODE.toInteger()
-        versionName VERSION_NAME
+        versionCode KA_VERSION_CODE.toInteger()
+        versionName KA_VERSION_NAME
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments disableAnalytics: 'true'

--- a/android/features/android-feature-toast-utils/build.gradle
+++ b/android/features/android-feature-toast-utils/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion KAversions.minSdk
         targetSdkVersion KAversions.compileSdk
-        versionCode VERSION_CODE.toInteger()
-        versionName VERSION_NAME
+        versionCode KA_VERSION_CODE.toInteger()
+        versionName KA_VERSION_NAME
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments disableAnalytics: 'true'

--- a/android/features/android-feature-viewmodel/build.gradle
+++ b/android/features/android-feature-viewmodel/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion KAversions.minSdk
         targetSdkVersion KAversions.compileSdk
-        versionCode VERSION_CODE.toInteger()
-        versionName VERSION_NAME
+        versionCode KA_VERSION_CODE.toInteger()
+        versionName KA_VERSION_NAME
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments disableAnalytics: 'true'

--- a/android/features/authentication/android-feature-authentication-core/build.gradle
+++ b/android/features/authentication/android-feature-authentication-core/build.gradle
@@ -10,8 +10,8 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion KAversions.compileSdk
-        versionCode VERSION_CODE.toInteger()
-        versionName VERSION_NAME
+        versionCode KA_VERSION_CODE.toInteger()
+        versionName KA_VERSION_NAME
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments disableAnalytics: 'true'

--- a/gradle.properties
+++ b/gradle.properties
@@ -37,10 +37,10 @@ kapt.include.compile.classpath=false
 # Enable In Logcat to determine Kapt
 #kapt.verbose=true
 
-VERSION_NAME=1.0.0-SNAPSHOT
+KA_VERSION_NAME=1.0.0-SNAPSHOT
 
 # The trailing 2 digits are for `alpha##` releases. For example:
 #     4.4.1-alpha02 = 441102 where `102` stands for alpha02
 #     4.4.1-beta01 = 441201 where `201` stands for beta01
 #     4.4.1-rc01 = 441301 where `301` stands for rc01
-VERSION_CODE=100000
+KA_VERSION_CODE=100000

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "io.matthewnelson.kotlin_android"
         minSdkVersion 21
         targetSdkVersion KAversions.compileSdk
-        versionCode VERSION_CODE.toInteger()
-        versionName VERSION_NAME
+        versionCode KA_VERSION_CODE.toInteger()
+        versionName KA_VERSION_NAME
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments disableAnalytics: 'true'


### PR DESCRIPTION
Makes the `gradle.properties` values `VERSION_NAME` and `VERSION_CODE` more unique to Kotlin-Android to reduce submodule conflicts.