### PR TITLE
Move Java 1.8 compatibility options to root project build.gradle

### DIFF
--- a/android/concepts/android-concept-views/build.gradle
+++ b/android/concepts/android-concept-views/build.gradle
@@ -23,11 +23,6 @@ android {
             minifyEnabled false
         }
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {

--- a/android/features/android-feature-activity/build.gradle
+++ b/android/features/android-feature-activity/build.gradle
@@ -23,11 +23,6 @@ android {
             minifyEnabled false
         }
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {

--- a/android/features/android-feature-navigation/build.gradle
+++ b/android/features/android-feature-navigation/build.gradle
@@ -23,11 +23,6 @@ android {
             minifyEnabled false
         }
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {

--- a/android/features/android-feature-screens/build.gradle
+++ b/android/features/android-feature-screens/build.gradle
@@ -23,11 +23,6 @@ android {
             minifyEnabled false
         }
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {

--- a/android/features/android-feature-toast-utils/build.gradle
+++ b/android/features/android-feature-toast-utils/build.gradle
@@ -23,11 +23,6 @@ android {
             minifyEnabled false
         }
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {

--- a/android/features/android-feature-viewmodel/build.gradle
+++ b/android/features/android-feature-viewmodel/build.gradle
@@ -23,11 +23,6 @@ android {
             minifyEnabled false
         }
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {

--- a/android/features/authentication/android-feature-authentication-core/build.gradle
+++ b/android/features/authentication/android-feature-authentication-core/build.gradle
@@ -23,11 +23,6 @@ android {
             minifyEnabled false
         }
     }
-
-    compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
-    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,18 @@ allprojects {
         maxHeapSize = "4096m"
     }
 
+    plugins.withId("com.android.library") {
+        extensions.getByName("android").compileOptions {
+            sourceCompatibility JavaVersion.VERSION_1_8
+            targetCompatibility JavaVersion.VERSION_1_8
+        }
+    }
+
+    plugins.withId("kotlin") {
+        sourceCompatibility = JavaVersion.VERSION_1_8
+        targetCompatibility = JavaVersion.VERSION_1_8
+    }
+
     tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_1_8

--- a/kotlin/common/build-config/build.gradle
+++ b/kotlin/common/build-config/build.gradle
@@ -2,6 +2,3 @@ plugins {
     id 'java-library'
     id 'kotlin'
 }
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8

--- a/kotlin/concepts/authentication/concept-authentication-core/build.gradle
+++ b/kotlin/concepts/authentication/concept-authentication-core/build.gradle
@@ -4,9 +4,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     api project(path: ':kotlin:concepts:authentication:concept-authentication')

--- a/kotlin/concepts/authentication/concept-authentication/build.gradle
+++ b/kotlin/concepts/authentication/concept-authentication/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation KAdeps.kotlin.coroutinesCore

--- a/kotlin/concepts/authentication/concept-encryption-key/build.gradle
+++ b/kotlin/concepts/authentication/concept-encryption-key/build.gradle
@@ -4,9 +4,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     api project(path: ':kotlin:crypto:k-openssl-common')

--- a/kotlin/concepts/concept-coroutines/build.gradle
+++ b/kotlin/concepts/concept-coroutines/build.gradle
@@ -4,9 +4,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     api KAdeps.kotlin.coroutinesCore

--- a/kotlin/concepts/concept-foreground-state/build.gradle
+++ b/kotlin/concepts/concept-foreground-state/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation KAdeps.kotlin.coroutinesCore

--- a/kotlin/concepts/concept-navigation/build.gradle
+++ b/kotlin/concepts/concept-navigation/build.gradle
@@ -2,6 +2,3 @@ plugins {
     id 'java-library'
     id 'kotlin'
 }
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8

--- a/kotlin/concepts/concept-views/build.gradle
+++ b/kotlin/concepts/concept-views/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     api project(path: ':kotlin:concepts:concept-coroutines')

--- a/kotlin/crypto/bouncycastle-ktx/build.gradle
+++ b/kotlin/crypto/bouncycastle-ktx/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 //    implementation KAdeps.bouncyCastle

--- a/kotlin/crypto/k-openssl-common/build.gradle
+++ b/kotlin/crypto/k-openssl-common/build.gradle
@@ -2,6 +2,3 @@ plugins {
     id 'java-library'
     id 'kotlin'
 }
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8

--- a/kotlin/crypto/k-openssl/build.gradle
+++ b/kotlin/crypto/k-openssl/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation project(path: ':kotlin:crypto:bouncycastle-ktx')

--- a/kotlin/encoders/base32/build.gradle
+++ b/kotlin/encoders/base32/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     testImplementation KAtestDeps.junit
     testImplementation KAtestDeps.google.guava

--- a/kotlin/encoders/base64/build.gradle
+++ b/kotlin/encoders/base64/build.gradle
@@ -2,6 +2,3 @@ plugins {
     id 'java-library'
     id 'kotlin'
 }
-
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8

--- a/kotlin/features/authentication/feature-authentication-core/build.gradle
+++ b/kotlin/features/authentication/feature-authentication-core/build.gradle
@@ -4,9 +4,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     api project(path: ':kotlin:concepts:authentication:concept-authentication-core')

--- a/kotlin/features/authentication/feature-authentication-view/build.gradle
+++ b/kotlin/features/authentication/feature-authentication-view/build.gradle
@@ -4,9 +4,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     api project(path: ':kotlin:features:authentication:feature-authentication-core')

--- a/kotlin/features/feature-foreground-state/build.gradle
+++ b/kotlin/features/feature-foreground-state/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     api project(path: ':kotlin:concepts:concept-foreground-state')

--- a/kotlin/features/feature-navigation/build.gradle
+++ b/kotlin/features/feature-navigation/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     api project(path: ':kotlin:concepts:concept-navigation')

--- a/kotlin/test/test-concept-coroutines/build.gradle
+++ b/kotlin/test/test-concept-coroutines/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     api project(path: ':kotlin:concepts:concept-coroutines')

--- a/kotlin/test/test-k-openssl/build.gradle
+++ b/kotlin/test/test-k-openssl/build.gradle
@@ -3,9 +3,6 @@ plugins {
     id 'kotlin'
 }
 
-sourceCompatibility = JavaVersion.VERSION_1_8
-targetCompatibility = JavaVersion.VERSION_1_8
-
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     api project(path: ':kotlin:test:test-concept-coroutines')

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -19,8 +19,6 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         testInstrumentationRunnerArguments disableAnalytics: 'true'
-
-//        multiDexEnabled true
     }
 
     // Gradle 4.0's introduction of Google analytics to Android App Developers.

--- a/sample/src/main/res/layout/activity_main.xml
+++ b/sample/src/main/res/layout/activity_main.xml
@@ -9,7 +9,7 @@
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="Hello World!"
+        android:text="@string/kotlin_android"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintLeft_toLeftOf="parent"
         app:layout_constraintRight_toRightOf="parent"

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
 <!--    <string name="app_name">KotlinAndroid</string>-->
+    <string name="kotlin_android">Kotlin Android</string>
 </resources>


### PR DESCRIPTION
This PR moves modules' source/target compatibility options for Java 1.8 to the root project's `build.gradle` file